### PR TITLE
Replace retry_standard_errors with poller_error_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Feature - Replace `retry_standard_errors` with `poller_error_handler`.
 * Feature - Support per queue configuration.
 * Feature - Support loading global and queue specific configuration from ENV.
 

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ end
 Configuring different behavior for different exceptions:
 
 ```ruby
-Aws::ActiveJob::SQS.configure do |config|
-  config.poller_error_handler do |exception, sqs_message|
+module MyErrorHandlers
+  HANDLE_ERRORS = proc do |exception, sqs_message|
     case exception
     when MyRetryableException
       # no-op, don't delete message
@@ -178,6 +178,10 @@ Aws::ActiveJob::SQS.configure do |config|
       raise exception
     end
   end
+end
+
+Aws::ActiveJob::SQS.configure do |config|
+  config.poller_error_handler = MyErrorHandlers::HANDLE_ERRORS
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -136,19 +136,51 @@ When configured, ActiveJob will catch the exception and reschedule the job for
 re-execution after the configured delay. This will delete the original
 message from the SQS queue and requeue a new message.
 
-By default SQS ActiveJob is configured with `retry_standard_error` set to `true`
-and will not delete messages for jobs that raise a `StandardError` and that do
-not handle that error via `retry_on` or `discard_on`. These job messages will
-remain on the queue and will be re-read and retried following the SQS Queue's
-configured
-[retry and DLQ settings](https://docs.aws.amazon.com/lambda/latest/operatorguide/sqs-retries.html).
+You can configure an error handler block for the ActiveJob SQS poller with 
+`poller_error_handler`. Jobs that raise a `StandardError` and that do
+not handle that error via `retry_on` or `discard_on` will be call the configured
+`poller_error_handler` with `|exception, sqs_message|`.
+You may re-raise the exception to terminate the poller. You may also choose 
+whether to delete the sqs_message or not.  If the message is not explicitly 
+deleted then the message will be left on the queue and will be retried
+following the SQS Queue's configured
+[retry and DLQ settings](https://docs.aws.amazon.com/lambda/latest/operatorguide/sqs-retries.html). 
+Retries provided by this mechanism are after any retries configured on the job
+with `retry_on`.
+
 If you do not have a DLQ configured, the message will continue to be attempted
 until it reaches the queues retention period.  In general, it is a best practice
 to configure a DLQ to store unprocessable jobs for troubleshooting and re-drive.
 
-If you want failed jobs that do not have `retry_on` or `discard_on` configured
-to be immediately discarded and not left on the queue, set `retry_standard_error`
-to `false`.
+Configuring retry/redrive for all `StandardErrors`:
+
+```ruby
+Aws::ActiveJob::SQS.configure do |config|
+  config.poller_error_handler do |_exception, _sqs_message|
+    # no-op, don't delete the message or re-raise the exception
+  end
+end
+```
+
+Configuring different behavior for different exceptions:
+
+```ruby
+Aws::ActiveJob::SQS.configure do |config|
+  config.poller_error_handler do |exception, sqs_message|
+    case exception
+    when MyRetryableException
+      # no-op, don't delete message
+    when MyTerminalException
+      # delete the message, preventing retry
+      sqs_message.delete
+    else
+      # unhandled exceptions, re-raise the exception to terminate the poller
+      raise exception
+    end
+  end
+end
+```
+
 
 When using the Async adapter, you may want to configure a
 `async_queue_error_handler` to handle errors that may occur when queuing jobs. 

--- a/lib/aws/active_job/sqs/configuration.rb
+++ b/lib/aws/active_job/sqs/configuration.rb
@@ -56,7 +56,6 @@ module Aws
           backpressure: 10,
           max_messages: 10,
           shutdown_timeout: 15,
-          retry_standard_errors: true, # TODO: Remove in next MV
           queues: {},
           logger: ::Rails.logger,
           message_group_id: 'SqsActiveJobGroup',
@@ -113,15 +112,15 @@ module Aws
         #   will not be deleted from the SQS queue and will be retryable after
         #   the visibility timeout.
         #
-        # @option options [Boolean] :retry_standard_errors
-        #   If `true`, StandardErrors raised by ActiveJobs are left on the queue
-        #   and will be retried (pending the SQS Queue's redrive/DLQ/maximum receive settings).
-        #   This behavior overrides the standard Rails ActiveJob
-        #   [Retry/Discard for failed jobs](https://guides.rubyonrails.org/active_job_basics.html#retrying-or-discarding-failed-jobs)
-        #   behavior.  When set to `true` the retries provided by this will be
-        #   on top of any retries configured on the job with `retry_on`.
-        #   When `false`, retry behavior is fully configured
-        #   through `retry_on`/`discard_on` on the ActiveJobs.
+        # @option options [Callable] :poller_error_handler and error handler to
+        #   be called when the poller encounters an error running a job.  Called
+        #   with exception, sqs_message. You may re-raise the exception to
+        #   terminate the poller. You may also choose whether to delete the
+        #   sqs_message or not.  If the message is not explicitly deleted
+        #   then the message will be left on the queue and will be
+        #   retried (pending the SQS Queue's redrive/DLQ/maximum
+        #   receive settings). Retries provided by this mechanism are
+        #   after any retries configured on the job with `retry_on`.
         #
         # @option options [ActiveSupport::Logger] :logger Logger to use
         #   for the poller.
@@ -159,14 +158,19 @@ module Aws
         # @api private
         attr_accessor :queues, :threads, :backpressure,
                       :shutdown_timeout, :client, :logger,
-                      :async_queue_error_handler,
-                      :retry_standard_errors
+                      :async_queue_error_handler
 
         # @api private
-        attr_writer :max_messages, :message_group_id, :visibility_timeout
+        attr_writer :max_messages, :message_group_id, :visibility_timeout,
+                    :poller_error_handler
 
         def excluded_deduplication_keys=(keys)
           @excluded_deduplication_keys = keys.map(&:to_s) | ['job_id']
+        end
+
+        def poller_error_handler(&block)
+          @poller_error_handler = block if block
+          @poller_error_handler
         end
 
         def client

--- a/lib/aws/active_job/sqs/configuration.rb
+++ b/lib/aws/active_job/sqs/configuration.rb
@@ -169,7 +169,7 @@ module Aws
         end
 
         def poller_error_handler(&block)
-          @poller_error_handler = block if block
+          @poller_error_handler = block if block_given?
           @poller_error_handler
         end
 

--- a/lib/aws/active_job/sqs/executor.rb
+++ b/lib/aws/active_job/sqs/executor.rb
@@ -100,12 +100,11 @@ module Aws
         # run in the @error_handler_thread
         def handle_errors
           # wait until errors are placed in the error queue
-          while ( (exception, message) = @error_queue.pop)
-            if @error_handler
-              @error_handler.call(exception, message)
-            else
-              raise exception
-            end
+          while ((exception, message) = @error_queue.pop)
+            raise exception unless @error_handler
+
+            @error_handler.call(exception, message)
+
           end
         rescue StandardError => e
           @logger.info("Unhandled exception executing jobs in poller: #{e}.")

--- a/lib/aws/active_job/sqs/poller.rb
+++ b/lib/aws/active_job/sqs/poller.rb
@@ -48,7 +48,7 @@ module Aws
             max_threads: config.threads,
             logger: @logger,
             max_queue: config.backpressure,
-            retry_standard_errors: config.retry_standard_errors
+            error_handler: config.poller_error_handler
           )
 
           poll
@@ -137,10 +137,6 @@ module Aws
             opts.on('-s', '--shutdown_timeout INTEGER', Integer,
                     'The amount of time to wait for a clean shutdown.  Jobs that are unable to complete in this time will not be deleted from the SQS queue and will be retryable after the visibility timeout.') do |a|
               out[:shutdown_timeout] = a
-            end
-            opts.on('--[no-]retry_standard_errors [FLAG]', TrueClass,
-                    'When set, retry all StandardErrors (leaving failed messages on the SQS Queue). These retries are ON TOP of standard Rails ActiveJob retries set by retry_on in the ActiveJob.') do |a|
-              out[:retry_standard_errors] = a.nil? ? true : a
             end
           end
 

--- a/spec/aws/active_job/sqs/configuration_spec.rb
+++ b/spec/aws/active_job/sqs/configuration_spec.rb
@@ -140,6 +140,16 @@ module Aws
           end
         end
 
+        describe '#poller_error_handler' do
+          it 'allows configuration through a block' do
+            cfg = Aws::ActiveJob::SQS::Configuration.new
+            cfg.poller_error_handler do
+              #  pass
+            end
+            expect(cfg.poller_error_handler).to be_a(Proc)
+          end
+        end
+
         Configuration::QUEUE_CONFIGS.each do |config_name|
           describe "##{config_name}_for" do
             let(:cfg) do


### PR DESCRIPTION
*Issue #, if available:*
#6 

*Description of changes:*
Replaces the `retry_standard_errors` with `poller_error_handler` which allows users to configure
more dynamic, flexible error handling behavior.

Handling errors from workers in the ThreadPool is complex. The current behavior of [`Concurrent::RubyThreadPoolExecutor`](https://github.com/ruby-concurrency/concurrent-ruby/blob/b5e090b9da95c63cd006721ae6a7e594ec78512b/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb#L358) which is the concrete implementation of `Concurrent::ThreadPoolExecutor` used by the executor does not propagate exceptions even when `Thread.abort_on_exception=true` is configured.  There are some details and work arounds discussed in https://github.com/ruby-concurrency/concurrent-ruby/issues/634 which has been open since 2017.

This PR works around the limitations by creating a error handling thread and a thread safe `Thread::Queue` which is used to pass exceptions between the worker threads and the error handler thread.  When an error is pushed onto the queue from a worker, it wakes up the error handler thread, which will run the conifugred error handler, and if nessecary, shutdown the executor and terminate the poller (by re-raising the thread upwards with `abort_on_exception`). 

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
