### PR TITLE
Support polling on multiple queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Feature - Allow polling on multiple queues. (#4)
-* Feature - Allow running without Rails. (#5)
+* Feature - Support polling on multiple queues. (#4)
+* Feature - Support running without Rails. (#5)
 * Feature - Replace `retry_standard_errors` with `poller_error_handler`. (#6)
 * Feature - Support per queue configuration. (#4)
 * Feature - Support loading global and queue specific configuration from ENV. (#3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased Changes
 ------------------
 
+* Feature - Allow polling on multiple queues. (#4)
 * Feature - Allow running without Rails. (#5)
 * Feature - Replace `retry_standard_errors` with `poller_error_handler`. (#6)
 * Feature - Support per queue configuration. (#4)

--- a/README.md
+++ b/README.md
@@ -197,7 +197,9 @@ for documentation.
 To start processing jobs, you need to start a separate process
 (in additional to your Rails app) with `bin/aws_active_job_sqs`
 (an executable script provided with this gem). You can poll for one or multiple
-queues using the `--queue` argument(s). You can  specify multiple queues 
+queues using the `--queue` argument(s). 
+
+You can specify multiple queues 
 in the arguments by passing`--queue` multiple times 
 (eg `--queue queue_1 --queue queue_2`) or for all configured queues by 
 providing no queue arguments. When multiple queues are specified, 1 thread 

--- a/README.md
+++ b/README.md
@@ -196,8 +196,17 @@ for documentation.
 
 To start processing jobs, you need to start a separate process
 (in additional to your Rails app) with `bin/aws_active_job_sqs`
-(an executable script provided with this gem).  You need to specify the queue to
-process jobs from:
+(an executable script provided with this gem). You can poll for one or multiple
+queues using the `--queue` argument(s). You can  specify multiple queues 
+in the arguments by passing`--queue` multiple times 
+(eg `--queue queue_1 --queue queue_2`) or for all configured queues by 
+providing no queue arguments. When multiple queues are specified, 1 thread 
+per queue is started to run the poller for that queue. All queues share a 
+single, common thread pool for executing jobs.
+
+It is generally recommended to start one polling process per queue instead of
+running a single poller for all queues as this generally allows you to better
+manage the resources used.
 
 ```sh
 RAILS_ENV=development bundle exec aws_active_job_sqs --queue default

--- a/bin/aws_active_job_sqs
+++ b/bin/aws_active_job_sqs
@@ -6,7 +6,6 @@ require_relative '../lib/aws/active_job/sqs/cli_options'
 require_relative '../lib/aws/active_job/sqs/poller'
 
 opts = Aws::ActiveJob::SQS::CliOptions.parse(ARGV)
-puts opts
 
 if opts[:boot_rails]
   require 'rails'

--- a/bin/aws_active_job_sqs
+++ b/bin/aws_active_job_sqs
@@ -6,6 +6,7 @@ require_relative '../lib/aws/active_job/sqs/cli_options'
 require_relative '../lib/aws/active_job/sqs/poller'
 
 opts = Aws::ActiveJob::SQS::CliOptions.parse(ARGV)
+puts opts
 
 if opts[:boot_rails]
   require 'rails'

--- a/lib/aws/active_job/sqs/cli_options.rb
+++ b/lib/aws/active_job/sqs/cli_options.rb
@@ -15,13 +15,13 @@ module Aws
         :visibility_timeout,
         :shutdown_timeout,
         :require,
-        :queue,
+        :queues,
         keyword_init: true
       ) do
         def self.parse(argv)
-          out = new(boot_rails: true)
+          out = new(boot_rails: true, queues: [])
           parser = ::OptionParser.new do |opts|
-            queue_option(opts, out)
+            queues_option(opts, out)
             threads_option(opts, out)
             backpressure_option(opts, out)
             max_messages_option(opts, out)
@@ -90,8 +90,10 @@ module Aws
           end
         end
 
-        def self.queue_option(opts, out)
-          opts.on('-q', '--queue STRING', '[Required] Queue to poll') { |a| out[:queue] = a }
+        def self.queues_option(opts, out)
+          opts.on('-q', '--queue STRING', 'Queue(s) to poll. You may specify this argument multiple times to poll multiple queues.  If not specified, will start pollers for all queues defined.') do |a|
+            out[:queues] << a
+          end
         end
       end
     end

--- a/lib/aws/active_job/sqs/cli_options.rb
+++ b/lib/aws/active_job/sqs/cli_options.rb
@@ -92,7 +92,7 @@ module Aws
 
         def self.queues_option(opts, out)
           opts.on('-q', '--queue STRING', 'Queue(s) to poll. You may specify this argument multiple times to poll multiple queues.  If not specified, will start pollers for all queues defined.') do |a|
-            out[:queues] << a
+            out[:queues] << a.to_sym
           end
         end
       end

--- a/lib/aws/active_job/sqs/poller.rb
+++ b/lib/aws/active_job/sqs/poller.rb
@@ -22,8 +22,6 @@ module Aws
             end
           end
 
-          validate_config
-
           config = Aws::ActiveJob::SQS.config
 
           # ensure we have a logger configured
@@ -89,10 +87,6 @@ module Aws
                                 ))
             end
           end
-        end
-
-        def validate_config
-          raise ArgumentError, 'You must specify the name of the queue to process jobs from' unless @options[:queue]
         end
       end
     end

--- a/lib/aws/active_job/sqs/poller.rb
+++ b/lib/aws/active_job/sqs/poller.rb
@@ -92,13 +92,12 @@ module Aws
             end
           end
           poller_threads.each(&:join)
-
         end
 
         def validate_config(queue)
-          unless Aws::ActiveJob::SQS.config.queues[queue.to_sym]&.fetch(:url)
-            raise ArgumentError, "No URL configured for queue #{queue}"
-          end
+          return if Aws::ActiveJob::SQS.config.queues[queue.to_sym]&.fetch(:url, nil)
+
+          raise ArgumentError, "No URL configured for queue #{queue}"
         end
 
         def poller_options(queue)

--- a/lib/aws/active_job/sqs/poller.rb
+++ b/lib/aws/active_job/sqs/poller.rb
@@ -95,7 +95,7 @@ module Aws
         end
 
         def validate_config(queue)
-          return if Aws::ActiveJob::SQS.config.queues[queue.to_sym]&.fetch(:url, nil)
+          return if Aws::ActiveJob::SQS.config.queues[queue]&.fetch(:url, nil)
 
           raise ArgumentError, "No URL configured for queue #{queue}"
         end


### PR DESCRIPTION
*Issue #, if available:*
#4 

*Description of changes:*
Adds support for running the poller on multiple queues.  You can either specify multiple queues in the arguments by passing `--queue` multiple times ( eg `--queue queue_1 --queue queue_2`) or for all configured queues by providing no queue arguments.

When multiple queues are specified, 1 thread per queue is started to run the poller for that queue.  All queues share a single, common thread pool for executing jobs.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
