### PR TITLE
Handle Time objects in ActiveJob.perform_all_later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Issue - Remove `aws_sqs_active_job` executable. 
+* Issue - Remove `aws_sqs_active_job` executable.
+* Issue - Handle `Time` objects correctly when using `ActiveJob.perform_all_later`.
 
 1.0.1 (2024-12-23)
 ------------------

--- a/lib/active_job/queue_adapters/sqs_adapter/params.rb
+++ b/lib/active_job/queue_adapters/sqs_adapter/params.rb
@@ -9,9 +9,10 @@ module ActiveJob
         class << self
           def assured_delay_seconds(timestamp)
             delay = (timestamp.to_f - Time.now.to_f).floor
+            delay = 0 if delay.negative?
             raise ArgumentError, 'Unable to queue a job with a delay great than 15 minutes' if delay > 15.minutes
 
-            [delay, 0].max
+            delay
           end
         end
 

--- a/lib/active_job/queue_adapters/sqs_adapter/params.rb
+++ b/lib/active_job/queue_adapters/sqs_adapter/params.rb
@@ -8,11 +8,10 @@ module ActiveJob
       class Params
         class << self
           def assured_delay_seconds(timestamp)
-            delay = (timestamp - Time.now.to_f).floor
-            delay = 0 if delay.negative?
+            delay = (timestamp.to_f - Time.now.to_f).floor
             raise ArgumentError, 'Unable to queue a job with a delay great than 15 minutes' if delay > 15.minutes
 
-            delay
+            [delay, 0].max
           end
         end
 

--- a/lib/aws/active_job/sqs/cli_options.rb
+++ b/lib/aws/active_job/sqs/cli_options.rb
@@ -47,7 +47,7 @@ module Aws
         def self.boot_rails_option(opts, out)
           doc = 'When set boots rails before running the poller.'
           opts.on('--[no-]rails [FLAG]', TrueClass, doc) do |a|
-            out[:boot_rails] = a.nil? ? true : a
+            out[:boot_rails] = a.nil? || a
           end
         end
 

--- a/lib/aws/active_job/sqs/poller.rb
+++ b/lib/aws/active_job/sqs/poller.rb
@@ -100,7 +100,6 @@ module Aws
         end
 
         def validate_config(queue)
-          puts Aws::ActiveJob::SQS.config.queues
           return if Aws::ActiveJob::SQS.config.queues[queue]&.fetch(:url, nil)
 
           raise ArgumentError, "No URL configured for queue #{queue}"

--- a/spec/active_job/queue_adapters/sqs_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sqs_adapter_spec.rb
@@ -199,11 +199,13 @@ module ActiveJob
               queue_url: 'https://queue-url',
               entries: [
                 {
+                  delay_seconds: instance_of(Integer),
                   id: instance_of(String),
                   message_body: instance_of(String),
                   message_attributes: instance_of(Hash)
                 },
                 {
+                  delay_seconds: instance_of(Integer),
                   id: instance_of(String),
                   message_body: instance_of(String),
                   message_attributes: instance_of(Hash)


### PR DESCRIPTION
Closes #23 

When using `ActiveJob.perform_all_later`, it calls our `enqueue_batches` which sets passes `job.scheduled_at` as a timestamp. That timestamp is not correctly being converted into a float for comparison.