### PR TITLE
Assign aws message id.

### DIFF
--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -9,6 +9,7 @@ module Aws
 
         def initialize(message)
           @job_data = ActiveSupport::JSON.load(message.data.body)
+          @job_data['provider_job_id'] = message.data.message_id
           @class_name = @job_data['job_class'].constantize
           @id = @job_data['job_id']
         end

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -8,8 +8,8 @@ module Aws
         attr_reader :id, :class_name
 
         def initialize(message)
-          @job_data = ActiveSupport::JSON.load(message.data.body)
-          @job_data['provider_job_id'] = message.data.message_id
+          @job_data = ActiveSupport::JSON.load(message.body)
+          @job_data['provider_job_id'] = message.message_id
           @class_name = @job_data['job_class'].constantize
           @id = @job_data['job_id']
         end

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -9,7 +9,7 @@ module Aws
         let(:message_id) { '12345' }
         let(:job_data) { job_serialized.merge('provider_job_id' => message_id) }
         let(:msg) do
-          instance_double(Aws::SQS::Message, data: double(body: body, message_id: message_id))
+          Aws::SQS::Message.new(receipt_handle: 'receipt_handle', queue_url: 'queue_url', data: { body: body, message_id: message_id })
         end
         let(:instance) { described_class.new(msg) }
 

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -18,9 +18,11 @@ module Aws
         end
 
         describe '#run' do
+          subject { instance.run }
+
           it 'calls Base.execute with the job data' do
             expect(::ActiveJob::Base).to receive(:execute).with(job_data).and_call_original
-            instance.run
+            subject
           end
         end
       end

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -9,7 +9,9 @@ module Aws
         let(:message_id) { '12345' }
         let(:job_data) { job_serialized.merge('provider_job_id' => message_id) }
         let(:msg) do
-          Aws::SQS::Message.new(receipt_handle: 'receipt_handle', queue_url: 'queue_url', data: { body: body, message_id: message_id })
+          Aws::SQS::Message.new(receipt_handle: 'receipt_handle',
+                                queue_url: 'queue_url',
+                                data: { body: body, message_id: message_id })
         end
         let(:instance) { described_class.new(msg) }
 

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -4,20 +4,23 @@ module Aws
   module ActiveJob
     module SQS
       describe JobRunner do
-        let(:job_data) { TestJob.new('a1', 'a2').serialize }
-        let(:body) { ActiveSupport::JSON.dump(job_data) }
-        # message is a reserved minitest name
-        let(:msg) { double(data: double(body: body)) }
+        let(:job_serialized) { TestJob.new('a1', 'a2').serialize }
+        let(:body) { ActiveSupport::JSON.dump(job_serialized) }
+        let(:message_id) { '12345' }
+        let(:job_data) { job_serialized.merge('provider_job_id' => message_id) }
+        let(:msg) do
+          instance_double(Aws::SQS::Message, data: double(body: body, message_id: message_id))
+        end
+        let(:instance) { described_class.new(msg) }
 
         it 'parses the job data' do
-          job_runner = JobRunner.new(msg)
-          expect(job_runner.instance_variable_get(:@job_data)).to eq job_data
+          expect(instance.instance_variable_get(:@job_data)).to eq(job_data)
         end
 
         describe '#run' do
           it 'calls Base.execute with the job data' do
-            expect(::ActiveJob::Base).to receive(:execute).with(job_data)
-            JobRunner.new(msg).run
+            expect(::ActiveJob::Base).to receive(:execute).with(job_data).and_call_original
+            instance.run
           end
         end
       end


### PR DESCRIPTION
*Issue #, if available:* 

There is no issue, is just about missing data and ability to improve logging afterwards.

*Description of changes:*

The PR assigns `provider_job_id` | ID optionally provided by adapter. You have more information about this here:
https://api.rubyonrails.org/classes/ActiveJob/Core.html

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
