### PR TITLE
Assign provider_id when message is pushed to SQS.

### DIFF
--- a/lib/active_job/queue_adapters/sqs_adapter.rb
+++ b/lib/active_job/queue_adapters/sqs_adapter.rb
@@ -66,7 +66,8 @@ module ActiveJob
         params = Params.new(job, body)
         send_message_opts = send_message_opts.merge(params.entry)
         send_message_opts[:queue_url] = params.queue_url
-        Aws::ActiveJob::SQS.config.client.send_message(send_message_opts)
+        response = Aws::ActiveJob::SQS.config.client.send_message(send_message_opts)
+        job.provider_job_id = response.message_id
       end
     end
   end

--- a/spec/active_job/queue_adapters/sqs_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sqs_adapter_spec.rb
@@ -4,21 +4,41 @@ module ActiveJob
   module QueueAdapters
     describe SqsAdapter do
       let(:client) { double('Client') }
+      let(:aws_message_id) { '12345' }
+      let(:message_result) { instance_double(Aws::SQS::Types::SendMessageResult, message_id: aws_message_id) }
       before do
         allow(Aws::ActiveJob::SQS.config).to receive(:client).and_return(client)
       end
 
-      it 'enqueues jobs' do
-        expect(client).to receive(:send_message)
-          .with(
-            {
-              queue_url: 'https://queue-url',
-              message_body: instance_of(String),
-              message_attributes: instance_of(Hash)
-            }
-          )
-        TestJob.perform_later('test')
-        sleep(0.2)
+      context '.perform_later' do
+        it 'returns a job with provider_job_id assigned' do
+          expect(client).to receive(:send_message)
+            .with(
+              {
+                queue_url: 'https://queue-url',
+                message_body: instance_of(String),
+                message_attributes: instance_of(Hash)
+              }
+            )
+            .and_return(message_result)
+          job = TestJob.perform_later('test')
+          expect(job).to be_a(TestJob)
+          expect(job.provider_job_id).to eq(aws_message_id)
+        end
+
+        it 'enqueues jobs' do
+          expect(client).to receive(:send_message)
+            .with(
+              {
+                queue_url: 'https://queue-url',
+                message_body: instance_of(String),
+                message_attributes: instance_of(Hash)
+              }
+            )
+            .and_return(message_result)
+          TestJob.perform_later('test')
+          sleep(0.2)
+        end
       end
 
       context 'fifo queues' do
@@ -37,6 +57,7 @@ module ActiveJob
                 message_deduplication_id: instance_of(String)
               }
             )
+            .and_return(message_result)
           TestJob.perform_later('test')
           sleep(0.2)
         end
@@ -66,6 +87,7 @@ module ActiveJob
                   message_deduplication_id: hashed_body
                 }
               )
+                                                      .and_return(message_result)
 
               TestJobWithDedupKeys.perform_later('test')
               sleep(0.2)
@@ -94,6 +116,7 @@ module ActiveJob
                   message_deduplication_id: hashed_body
                 }
               )
+                                                      .and_return(message_result)
 
               TestJob.perform_later('test')
               sleep(0.2)
@@ -112,6 +135,7 @@ module ActiveJob
                 message_deduplication_id: instance_of(String)
               }
             )
+                                                    .and_return(message_result)
 
             TestJobWithMessageGroupID.perform_later('test')
             sleep(0.2)
@@ -131,6 +155,7 @@ module ActiveJob
                 message_deduplication_id: instance_of(String)
               }
             )
+                                                   .and_return(message_result)
 
             expect(TestJobWithMessageGroupID).to receive(:new).with(arg).and_return(dbl)
             expect(dbl).to receive(:message_group_id).and_return(message_group_id)
@@ -154,6 +179,7 @@ module ActiveJob
               message_attributes: instance_of(Hash)
             }
           )
+                                                  .and_return(message_result)
 
           TestJob.set(wait: 1.minute).perform_later('test')
           sleep(0.2)
@@ -170,7 +196,7 @@ module ActiveJob
               message_body: instance_of(String),
               message_attributes: instance_of(Hash)
             }
-          ).twice
+          ).twice.and_return(message_result)
 
           TestJob.set(wait: 0).perform_later('test')
           TestJob.set(wait: -1).perform_later('test')

--- a/spec/active_job/queue_adapters/sqs_async_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sqs_async_adapter_spec.rb
@@ -4,6 +4,7 @@ module ActiveJob
   module QueueAdapters
     describe SqsAsyncAdapter do
       let(:client) { double('Client') }
+      let(:message_result) { instance_double(Aws::SQS::Types::SendMessageResult, message_id: '12345') }
 
       before do
         allow(Aws::ActiveJob::SQS.config).to receive(:client).and_return(client)
@@ -61,7 +62,7 @@ module ActiveJob
         allow(Aws::ActiveJob::SQS.config).to receive(:url_for)
           .and_return('https://queue-url.fifo')
         expect(Concurrent::Promises).not_to receive(:future)
-        expect(client).to receive(:send_message)
+        expect(client).to receive(:send_message).and_return(message_result)
 
         TestJobAsync.perform_later('test')
         sleep(0.2)


### PR DESCRIPTION
*Issue #, if available:*

No issue, just completing information.

*Description of changes:*

My guesses are the job is passed as a reference and this assign the aws_message_id to the job, if not mistaken the rails framework returns the job instance when `perform_later` is executed. 

I'm not sure, but I think the output of this enqueue is checked by rails framework as boolean succeed or not succeed... and either returning something like the output of the send_message or string will be considered as succeed...

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
