### PR TITLE
Fixed type.

### DIFF
--- a/lib/aws/active_job/sqs/lambda_handler.rb
+++ b/lib/aws/active_job/sqs/lambda_handler.rb
@@ -29,17 +29,17 @@ module Aws
           private
 
           def to_sqs_msg(record)
-            msg = Aws::SQS::Types::Message.new(
+            data = {
               body: record['body'],
               md5_of_body: record['md5OfBody'],
               message_attributes: to_message_attributes(record),
               message_id: record['messageId'],
               receipt_handle: record['receiptHandle']
-            )
+            }
             Aws::SQS::Message.new(
               queue_url: to_queue_url(record),
-              receipt_handle: msg.receipt_handle,
-              data: msg,
+              receipt_handle: msg[:receipt_handle],
+              data: data,
               client: Aws::ActiveJob::SQS.config.client
             )
           end


### PR DESCRIPTION
*Issue #, if available:*

incorrect type.

*Description of changes:*

If you take a look into the implementation, https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-sqs/lib/aws-sdk-sqs/message.rb#L50 data parameter is a hash.


By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
