### PR TITLE
feat: Restrict which classes the SQS poller will execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Issue - Validate that job classes inherit from `ActiveJob::Base` before execution.
-* Feature - Add optional `job_class_allowlist` configuration to restrict which job classes can be dispatched.
+* Issue - Only classes inheriting from `ActiveJob::Base` are executed by the poller, preventing arbitrary classes named in an SQS message from being instantiated and run.
+* Feature - Add optional `job_class_allowlist` configuration to restrict which job classes can be dispatched. Configurable in code, the config YAML file, or via the `AWS_ACTIVE_JOB_SQS_JOB_CLASS_ALLOWLIST` environment variable.
 
 1.0.2 (2025-04-01)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased Changes
 ------------------
 
+* Issue - Validate that job classes inherit from `ActiveJob::Base` before execution.
+* Feature - Add optional `job_class_allowlist` configuration to restrict which job classes can be dispatched.
+
 1.0.2 (2025-04-01)
 ------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Unreleased Changes
 ------------------
 
-* Issue - Only classes inheriting from `ActiveJob::Base` are executed by the poller, preventing arbitrary classes named in an SQS message from being instantiated and run.
-* Feature - Add optional `job_class_allowlist` configuration to restrict which job classes can be dispatched. Configurable in code, the config YAML file, or via the `AWS_ACTIVE_JOB_SQS_JOB_CLASS_ALLOWLIST` environment variable.
+* Issue - Only classes inheriting from `ActiveJob::Base` are executed by the poller, preventing arbitrary classes named in an SQS message from being instantiated and run. Job class names are validated as constant paths and resolved without searching the namespace's ancestors, so a message cannot name a constant outside the intended namespace.
+* Feature - Add optional `job_class_allowlist` configuration to restrict which job classes can be dispatched. Configurable in code, the config YAML file, or via the `AWS_ACTIVE_JOB_SQS_JOB_CLASS_ALLOWLIST` environment variable. When set, the allowlist is checked before the class name is resolved, so an excluded class is never loaded.
 
 1.0.2 (2025-04-01)
 ------------------

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,11 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', require: false
+if defined?(JRUBY_VERSION)
+  gem 'rdoc', '< 8.0.0'
+else
+  gem 'rdoc'
+end
 
 case ENV.fetch('RAILS_VERSION', nil)
 when '7.1'

--- a/README.md
+++ b/README.md
@@ -114,9 +114,15 @@ export AWS_ACTIVE_JOB_SQS_DEFAULT_URL = https://my-queue.aws
 ### Restricting which job classes can run
 
 The poller only executes classes that inherit from `ActiveJob::Base`, so an
-arbitrary class named in an SQS message cannot be instantiated and run. To
-restrict execution further, set `job_class_allowlist` to the classes you expect
-to process. When set, any job whose class is not in the list is rejected.
+arbitrary class named in an SQS message cannot be instantiated and run.
+
+To restrict execution further, set `job_class_allowlist` to the classes you
+expect to process. When set, any job whose class is not in the list is
+rejected. The allowlist is also checked before the class name is resolved, so a
+message naming a class outside the list cannot cause that class to be loaded.
+Setting it is recommended when the queue is reachable by anything you do not
+control, since it makes the set of executable classes explicit rather than
+"every job class in the application".
 
 In code, entries may be Class objects or class name Strings:
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,36 @@ export AWS_ACTIVE_JOB_SQS_MAX_MESSAGES = 5
 export AWS_ACTIVE_JOB_SQS_DEFAULT_URL = https://my-queue.aws
 ```
 
+### Restricting which job classes can run
+
+The poller only executes classes that inherit from `ActiveJob::Base`, so an
+arbitrary class named in an SQS message cannot be instantiated and run. To
+restrict execution further, set `job_class_allowlist` to the classes you expect
+to process. When set, any job whose class is not in the list is rejected.
+
+In code, entries may be Class objects or class name Strings:
+
+```ruby
+Aws::ActiveJob::SQS.configure do |config|
+  config.job_class_allowlist = [MyJob, 'OtherJob']
+end
+```
+
+In the YAML file, provide a list of class names:
+
+```yaml
+# config/aws_active_job_sqs.yml
+job_class_allowlist:
+  - MyJob
+  - OtherJob
+```
+
+Through the environment, provide a comma-separated list of class names:
+
+```shell
+export AWS_ACTIVE_JOB_SQS_JOB_CLASS_ALLOWLIST="MyJob,OtherJob"
+```
+
 ## Usage
 
 To queue a job, you can just use standard ActiveJob methods:

--- a/lib/aws/active_job/sqs/configuration.rb
+++ b/lib/aws/active_job/sqs/configuration.rb
@@ -69,6 +69,7 @@ module Aws
           shutdown_timeout
           visibility_timeout
           message_group_id
+          job_class_allowlist
         ].freeze
 
         QUEUE_ENV_CONFIGS = %i[
@@ -149,10 +150,12 @@ module Aws
         #   The type of keys stored in the array should be String or Symbol.
         #   Using this option, job_id is implicitly added to the keys.
         #
-        # @option options [Array<Class>, nil] :job_class_allowlist (nil)
-        #   An optional list of job classes that are permitted to be executed.
-        #   When set, only classes in this list will be dispatched. When nil,
-        #   any class inheriting from ActiveJob::Base is allowed.
+        # @option options [Array<Class, String>, String, nil] :job_class_allowlist (nil)
+        #   An optional list of job classes permitted to be executed. When set,
+        #   only classes in this list are dispatched; when nil, any class
+        #   inheriting from ActiveJob::Base is allowed. Entries may be Class
+        #   objects or class name Strings (in code/YAML), or a comma-separated
+        #   String of class names (from ENV), and are compared by class name.
 
         def initialize(options = {})
           opts = env_options.deep_merge(options)

--- a/lib/aws/active_job/sqs/configuration.rb
+++ b/lib/aws/active_job/sqs/configuration.rb
@@ -148,6 +148,11 @@ module Aws
         # @option options [Array] :excluded_deduplication_keys (['job_id'])
         #   The type of keys stored in the array should be String or Symbol.
         #   Using this option, job_id is implicitly added to the keys.
+        #
+        # @option options [Array<Class>, nil] :job_class_allowlist (nil)
+        #   An optional list of job classes that are permitted to be executed.
+        #   When set, only classes in this list will be dispatched. When nil,
+        #   any class inheriting from ActiveJob::Base is allowed.
 
         def initialize(options = {})
           opts = env_options.deep_merge(options)
@@ -160,7 +165,8 @@ module Aws
         # @api private
         attr_accessor :queues, :threads, :backpressure,
                       :shutdown_timeout, :logger,
-                      :async_queue_error_handler
+                      :async_queue_error_handler,
+                      :job_class_allowlist
 
         # @api private
         attr_writer :max_messages, :message_group_id, :visibility_timeout,

--- a/lib/aws/active_job/sqs/executor.rb
+++ b/lib/aws/active_job/sqs/executor.rb
@@ -91,11 +91,28 @@ module Aws
           job.run
           message.delete
         rescue JSON::ParserError => e
-          @logger.error "Unable to parse message body: #{message.data.body}. Error: #{e}."
+          # An unparseable body is a permanent failure: the message content is
+          # immutable, so re-parsing it on redelivery can never succeed. Log and
+          # delete it so it does not redeliver indefinitely.
+          drop_permanent_failure(message, "Unable to parse message body: #{message.data.body}. Error: #{e}.")
+        rescue InvalidJobClassError => e
+          # A bad job class is a permanent failure: redelivering it can never
+          # succeed and, on the default config, would crash-loop the poller.
+          # Log the forensic detail (the message can't be inspected in a DLQ
+          # once deleted) and delete it so it does not redeliver.
+          drop_permanent_failure(message, "Rejecting message #{message.message_id}: #{e}. " \
+                                          "Body: #{message.data.body}. Deleting so it does not redeliver.")
         rescue StandardError => e
           handle_standard_error(e, job, message)
         ensure
           @task_complete.set
+        end
+
+        # Log a permanently-failed message and delete it so SQS does not
+        # redeliver it (which, on the default config, would crash-loop the poller).
+        def drop_permanent_failure(message, log_message)
+          @logger.error log_message
+          message.delete
         end
 
         def handle_standard_error(error, job, message)

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -25,15 +25,24 @@ module Aws
         private
 
         def resolve_job_class(name)
-          klass = name.constantize
+          klass = name.safe_constantize
           unless klass.is_a?(Class) && klass < ::ActiveJob::Base
             raise ArgumentError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
           end
 
-          allowlist = Aws::ActiveJob::SQS.config.job_class_allowlist
-          return klass unless allowlist && !allowlist.include?(klass)
+          allowlist = normalized_allowlist
+          return klass if allowlist.nil? || allowlist.include?(klass.name)
 
           raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
+        end
+
+        # The allowlist may be configured as an Array of Class values (in code),
+        # an Array of Strings (from the YAML file), or a comma-separated String
+        # (from ENV). Normalize all forms to an Array of class name Strings.
+        def normalized_allowlist
+          allowlist = Aws::ActiveJob::SQS.config.job_class_allowlist
+          allowlist = allowlist.split(',') if allowlist.is_a?(String)
+          allowlist&.map { |entry| entry.to_s.strip }
         end
       end
     end

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -8,9 +8,7 @@ module Aws
       # job_class_allowlist, it is undefined, or it does not name a class
       # inheriting from ActiveJob::Base. This is a permanent
       # failure: such a message can never succeed, so the executor logs and
-      # deletes it rather than letting it redeliver. A dedicated type (rather
-      # than a generic ArgumentError) keeps it distinct from errors raised from
-      # inside a job's own #perform, which remain retryable.
+      # deletes it rather than letting it redeliver.
       class InvalidJobClassError < StandardError; end
 
       # @api private

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -29,11 +29,11 @@ module Aws
           unless klass.is_a?(Class) && klass < ::ActiveJob::Base
             raise ArgumentError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
           end
+
           allowlist = Aws::ActiveJob::SQS.config.job_class_allowlist
-          if allowlist && !allowlist.include?(klass)
-            raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
-          end
-          klass
+          return klass unless allowlist && !allowlist.include?(klass)
+
+          raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
         end
       end
     end

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -3,9 +3,10 @@
 module Aws
   module ActiveJob
     module SQS
-      # Raised when a message names a job class that cannot be executed:
-      # either it does not name a class inheriting from ActiveJob::Base, or it
-      # is not in the configured job_class_allowlist. This is a permanent
+      # Raised when a message names a job class that cannot be executed: the
+      # name is not a well-formed constant path, it is not in the configured
+      # job_class_allowlist, it is undefined, or it does not name a class
+      # inheriting from ActiveJob::Base. This is a permanent
       # failure: such a message can never succeed, so the executor logs and
       # deletes it rather than letting it redeliver. A dedicated type (rather
       # than a generic ArgumentError) keeps it distinct from errors raised from
@@ -14,6 +15,11 @@ module Aws
 
       # @api private
       class JobRunner
+        # A job class name is an (optionally namespaced) constant path and
+        # nothing else. Names that cannot match this can never name a job
+        # class, so rejecting them keeps them out of the constant lookup.
+        JOB_CLASS_NAME_PATTERN = /\A[A-Z]\w*(::[A-Z]\w*)*\z/.freeze
+
         attr_reader :id, :class_name
 
         def initialize(message)
@@ -33,16 +39,40 @@ module Aws
 
         private
 
+        # Checks are ordered so that the least trusting one runs first. Merely
+        # resolving a constant is not inert: in Rails it triggers autoloading,
+        # which runs the body of whichever file defines it. So the name is
+        # matched against the allowlist as a String, before any lookup, and an
+        # excluded name never reaches the constant resolver at all.
         def resolve_job_class(name)
-          klass = name.safe_constantize
+          name = name.to_s
+          unless JOB_CLASS_NAME_PATTERN.match?(name)
+            raise InvalidJobClassError, "#{name.inspect} is not a valid job class name"
+          end
+
+          allowlist = normalized_allowlist
+          if allowlist && !allowlist.include?(name)
+            raise InvalidJobClassError, "#{name} is not in the configured job_class_allowlist"
+          end
+
+          klass = constantize_job_class(name)
           unless klass.is_a?(Class) && klass < ::ActiveJob::Base
             raise InvalidJobClassError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
           end
 
-          allowlist = normalized_allowlist
-          return klass if allowlist.nil? || allowlist.include?(klass.name)
+          klass
+        end
 
-          raise InvalidJobClassError, "#{name} is not in the configured job_class_allowlist"
+        # Resolves an already-validated name. +inherit+ is false so that each
+        # segment must be defined directly on the preceding one: a name such
+        # as 'SomeJob::Foo' cannot resolve Foo from SomeJob's ancestors when
+        # SomeJob itself does not define it. NameError is treated as a
+        # rejection rather than propagated: an unknown class is the same
+        # permanent failure as a disallowed one.
+        def constantize_job_class(name)
+          Object.const_get(name, false)
+        rescue NameError
+          raise InvalidJobClassError, "#{name} is not defined"
         end
 
         # The allowlist may be configured as an Array of Class values (in code),

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -3,6 +3,15 @@
 module Aws
   module ActiveJob
     module SQS
+      # Raised when a message names a job class that cannot be executed:
+      # either it does not name a class inheriting from ActiveJob::Base, or it
+      # is not in the configured job_class_allowlist. This is a permanent
+      # failure: such a message can never succeed, so the executor logs and
+      # deletes it rather than letting it redeliver. A dedicated type (rather
+      # than a generic ArgumentError) keeps it distinct from errors raised from
+      # inside a job's own #perform, which remain retryable.
+      class InvalidJobClassError < StandardError; end
+
       # @api private
       class JobRunner
         attr_reader :id, :class_name
@@ -27,13 +36,13 @@ module Aws
         def resolve_job_class(name)
           klass = name.safe_constantize
           unless klass.is_a?(Class) && klass < ::ActiveJob::Base
-            raise ArgumentError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
+            raise InvalidJobClassError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
           end
 
           allowlist = normalized_allowlist
           return klass if allowlist.nil? || allowlist.include?(klass.name)
 
-          raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
+          raise InvalidJobClassError, "#{name} is not in the configured job_class_allowlist"
         end
 
         # The allowlist may be configured as an Array of Class values (in code),

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -9,7 +9,7 @@ module Aws
 
         def initialize(message)
           @job_data = ActiveSupport::JSON.load(message.data.body)
-          @class_name = @job_data['job_class'].constantize
+          @class_name = resolve_job_class(@job_data['job_class'])
           @id = @job_data['job_id']
         end
 
@@ -20,6 +20,20 @@ module Aws
         def exception_executions?
           @job_data['exception_executions'] &&
             !@job_data['exception_executions'].empty?
+        end
+
+        private
+
+        def resolve_job_class(name)
+          klass = name.constantize
+          unless klass.is_a?(Class) && klass < ::ActiveJob::Base
+            raise ArgumentError, "#{name} is not a valid job class (must inherit from ActiveJob::Base)"
+          end
+          allowlist = Aws::ActiveJob::SQS.config.job_class_allowlist
+          if allowlist && !allowlist.include?(klass)
+            raise ArgumentError, "#{name} is not in the configured job_class_allowlist"
+          end
+          klass
         end
       end
     end

--- a/spec/aws/active_job/sqs/executor_spec.rb
+++ b/spec/aws/active_job/sqs/executor_spec.rb
@@ -4,7 +4,7 @@ module Aws
   module ActiveJob
     module SQS
       describe Executor do
-        let(:logger) { double(info: nil, debug: nil) }
+        let(:logger) { double(info: nil, debug: nil, error: nil) }
 
         before do
           allow(ActiveSupport::Logger).to receive(:new).and_return(logger)
@@ -39,6 +39,27 @@ module Aws
               sleep(0.1) if defined?(JRUBY_VERSION)
               executor.shutdown # give the job a chance to run
             end.to raise_exception(StandardError)
+          end
+
+          it 'deletes the message and does not re-raise when the job class is invalid' do
+            expect(JobRunner).to receive(:new).and_raise(InvalidJobClassError, 'File is not a valid job class')
+            expect(msg).to receive(:delete)
+            expect(msg).to receive(:message_id).and_return('stub-id')
+            expect do
+              executor.execute(msg)
+              sleep(0.1) if defined?(JRUBY_VERSION)
+              executor.shutdown # give the task a chance to run
+            end.not_to raise_error
+          end
+
+          it 'deletes the message and does not re-raise when the body cannot be parsed' do
+            expect(JobRunner).to receive(:new).and_raise(JSON::ParserError.new('unexpected token'))
+            expect(msg).to receive(:delete)
+            expect do
+              executor.execute(msg)
+              sleep(0.1) if defined?(JRUBY_VERSION)
+              executor.shutdown # give the task a chance to run
+            end.not_to raise_error
           end
 
           describe 'error_handler' do

--- a/spec/aws/active_job/sqs/executor_spec.rb
+++ b/spec/aws/active_job/sqs/executor_spec.rb
@@ -47,8 +47,8 @@ module Aws
             let(:exception) { StandardError.new }
 
             it 'calls the error handler with exception and message' do
-              expect(JobRunner).to receive(:new).and_return(runner)
-              expect(runner).to receive(:run).and_raise exception
+              expect(JobRunner).to receive(:new).at_least(:once).and_return(runner)
+              expect(runner).to receive(:run).at_least(:once).and_raise exception
               expect(error_handler).to receive(:call).with(exception, msg)
               expect(executor).to receive(:shutdown).exactly(1).times.and_call_original
 

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -26,7 +26,7 @@ module Aws
             bad_data = job_data.merge('job_class' => 'String')
             bad_body = ActiveSupport::JSON.dump(bad_data)
             bad_msg = double(data: double(body: bad_body))
-            expect { JobRunner.new(bad_msg) }.to raise_error(ArgumentError, /not a valid job class/)
+            expect { JobRunner.new(bad_msg) }.to raise_error(InvalidJobClassError, /not a valid job class/)
           end
 
           context 'with job_class_allowlist configured' do
@@ -42,7 +42,7 @@ module Aws
               other_body = ActiveSupport::JSON.dump(other_data)
               other_msg = double(data: double(body: other_body))
               expect { JobRunner.new(other_msg) }
-                .to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
+                .to raise_error(InvalidJobClassError, /not in the configured job_class_allowlist/)
             end
           end
 
@@ -58,7 +58,7 @@ module Aws
               other_data = job_data.merge('job_class' => 'TestJobAsync')
               other_msg = double(data: double(body: ActiveSupport::JSON.dump(other_data)))
               expect { JobRunner.new(other_msg) }
-                .to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
+                .to raise_error(InvalidJobClassError, /not in the configured job_class_allowlist/)
             end
           end
 
@@ -74,7 +74,7 @@ module Aws
               other_data = job_data.merge('job_class' => 'TestJobAsync')
               other_msg = double(data: double(body: ActiveSupport::JSON.dump(other_data)))
               expect { JobRunner.new(other_msg) }
-                .to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
+                .to raise_error(InvalidJobClassError, /not in the configured job_class_allowlist/)
             end
           end
         end

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -45,6 +45,38 @@ module Aws
                 .to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
             end
           end
+
+          context 'with a string array allowlist (as loaded from YAML)' do
+            before { Aws::ActiveJob::SQS.config.job_class_allowlist = ['TestJob'] }
+            after { Aws::ActiveJob::SQS.config.job_class_allowlist = nil }
+
+            it 'allows classes whose name is in the allowlist' do
+              expect { JobRunner.new(msg) }.not_to raise_error
+            end
+
+            it 'rejects classes whose name is not in the allowlist' do
+              other_data = job_data.merge('job_class' => 'TestJobAsync')
+              other_msg = double(data: double(body: ActiveSupport::JSON.dump(other_data)))
+              expect { JobRunner.new(other_msg) }
+                .to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
+            end
+          end
+
+          context 'with a comma-separated string allowlist (as loaded from ENV)' do
+            before { Aws::ActiveJob::SQS.config.job_class_allowlist = 'SomeJob, TestJob ,OtherJob' }
+            after { Aws::ActiveJob::SQS.config.job_class_allowlist = nil }
+
+            it 'allows classes whose name is in the allowlist, ignoring whitespace' do
+              expect { JobRunner.new(msg) }.not_to raise_error
+            end
+
+            it 'rejects classes whose name is not in the allowlist' do
+              other_data = job_data.merge('job_class' => 'TestJobAsync')
+              other_msg = double(data: double(body: ActiveSupport::JSON.dump(other_data)))
+              expect { JobRunner.new(other_msg) }
+                .to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
+            end
+          end
         end
       end
     end

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -41,7 +41,8 @@ module Aws
               other_data = job_data.merge('job_class' => 'TestJobAsync')
               other_body = ActiveSupport::JSON.dump(other_data)
               other_msg = double(data: double(body: other_body))
-              expect { JobRunner.new(other_msg) }.to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
+              expect { JobRunner.new(other_msg) }
+                .to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
             end
           end
         end

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -20,6 +20,31 @@ module Aws
             JobRunner.new(msg).run
           end
         end
+
+        describe 'job class validation' do
+          it 'rejects classes that do not inherit from ActiveJob::Base' do
+            bad_data = job_data.merge('job_class' => 'String')
+            bad_body = ActiveSupport::JSON.dump(bad_data)
+            bad_msg = double(data: double(body: bad_body))
+            expect { JobRunner.new(bad_msg) }.to raise_error(ArgumentError, /not a valid job class/)
+          end
+
+          context 'with job_class_allowlist configured' do
+            before { Aws::ActiveJob::SQS.config.job_class_allowlist = [TestJob] }
+            after { Aws::ActiveJob::SQS.config.job_class_allowlist = nil }
+
+            it 'allows classes in the allowlist' do
+              expect { JobRunner.new(msg) }.not_to raise_error
+            end
+
+            it 'rejects classes not in the allowlist' do
+              other_data = job_data.merge('job_class' => 'TestJobAsync')
+              other_body = ActiveSupport::JSON.dump(other_data)
+              other_msg = double(data: double(body: other_body))
+              expect { JobRunner.new(other_msg) }.to raise_error(ArgumentError, /not in the configured job_class_allowlist/)
+            end
+          end
+        end
       end
     end
   end

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -22,11 +22,40 @@ module Aws
         end
 
         describe 'job class validation' do
+          def msg_for(class_name)
+            double(data: double(body: ActiveSupport::JSON.dump(job_data.merge('job_class' => class_name))))
+          end
+
           it 'rejects classes that do not inherit from ActiveJob::Base' do
-            bad_data = job_data.merge('job_class' => 'String')
-            bad_body = ActiveSupport::JSON.dump(bad_data)
-            bad_msg = double(data: double(body: bad_body))
-            expect { JobRunner.new(bad_msg) }.to raise_error(InvalidJobClassError, /not a valid job class/)
+            expect { JobRunner.new(msg_for('String')) }
+              .to raise_error(InvalidJobClassError, /must inherit from ActiveJob::Base/)
+          end
+
+          it 'rejects undefined classes' do
+            expect { JobRunner.new(msg_for('NoSuchJob')) }
+              .to raise_error(InvalidJobClassError, /is not defined/)
+          end
+
+          it 'rejects names that are not well-formed constant paths' do
+            ['', 'test_job', 'TestJob; puts 1', 'TestJob()', 'Test Job', '@job', 'Test-Job'].each do |name|
+              expect { JobRunner.new(msg_for(name)) }
+                .to raise_error(InvalidJobClassError, /is not a valid job class name/)
+            end
+          end
+
+          it 'rejects a name that resolves only through an ancestor of the namespace' do
+            # TestJob does not define ClassMethods, but its ancestors do, so
+            # an inheriting lookup would resolve this to
+            # ActiveJob::Exceptions::ClassMethods. Constants reachable only
+            # through the ancestor chain are not job classes and must not
+            # widen what a message can name.
+            expect { JobRunner.new(msg_for('TestJob::ClassMethods')) }
+              .to raise_error(InvalidJobClassError, /is not defined/)
+          end
+
+          it 'does not resolve the constant when the name is malformed' do
+            expect_any_instance_of(JobRunner).not_to receive(:constantize_job_class)
+            expect { JobRunner.new(msg_for('not_a_class_name')) }.to raise_error(InvalidJobClassError)
           end
 
           context 'with job_class_allowlist configured' do
@@ -38,10 +67,20 @@ module Aws
             end
 
             it 'rejects classes not in the allowlist' do
-              other_data = job_data.merge('job_class' => 'TestJobAsync')
-              other_body = ActiveSupport::JSON.dump(other_data)
-              other_msg = double(data: double(body: other_body))
-              expect { JobRunner.new(other_msg) }
+              expect { JobRunner.new(msg_for('TestJobAsync')) }
+                .to raise_error(InvalidJobClassError, /not in the configured job_class_allowlist/)
+            end
+
+            it 'rejects a disallowed name without resolving its constant' do
+              # Resolving is what triggers autoloading, so a name the allowlist
+              # excludes must be rejected before the lookup happens.
+              expect_any_instance_of(JobRunner).not_to receive(:constantize_job_class)
+              expect { JobRunner.new(msg_for('TestJobAsync')) }
+                .to raise_error(InvalidJobClassError, /not in the configured job_class_allowlist/)
+            end
+
+            it 'rejects a disallowed name even when it is undefined' do
+              expect { JobRunner.new(msg_for('NoSuchJob')) }
                 .to raise_error(InvalidJobClassError, /not in the configured job_class_allowlist/)
             end
           end
@@ -55,9 +94,7 @@ module Aws
             end
 
             it 'rejects classes whose name is not in the allowlist' do
-              other_data = job_data.merge('job_class' => 'TestJobAsync')
-              other_msg = double(data: double(body: ActiveSupport::JSON.dump(other_data)))
-              expect { JobRunner.new(other_msg) }
+              expect { JobRunner.new(msg_for('TestJobAsync')) }
                 .to raise_error(InvalidJobClassError, /not in the configured job_class_allowlist/)
             end
           end
@@ -71,9 +108,7 @@ module Aws
             end
 
             it 'rejects classes whose name is not in the allowlist' do
-              other_data = job_data.merge('job_class' => 'TestJobAsync')
-              other_msg = double(data: double(body: ActiveSupport::JSON.dump(other_data)))
-              expect { JobRunner.new(other_msg) }
+              expect { JobRunner.new(msg_for('TestJobAsync')) }
                 .to raise_error(InvalidJobClassError, /not in the configured job_class_allowlist/)
             end
           end


### PR DESCRIPTION
_This PR summary / description was written with help of AI._

## Summary

The poller deserializes an SQS message and executes the class named in its
`job_class` field. Previously any resolvable constant would be resolved and run,
so a message naming an arbitrary class could cause that class to be executed.
This change constrains what the poller will run.

## What this changes

`JobRunner#resolve_job_class` now applies three checks, ordered so the least
trusting one runs first:

1. **Name shape** - the name must match `JOB_CLASS_NAME_PATTERN`
   (`/\A[A-Z]\w*(::[A-Z]\w*)*\z/`), an optionally namespaced constant path and
   nothing else. Anything that cannot name a class is rejected before any lookup.
2. **Allowlist, compared as a String** - when `job_class_allowlist` is set, the
   raw name is matched against it *before* the constant is resolved.
3. **Resolve, then verify** - `Object.const_get(name, false)`, then a check that
   the result is a `Class` inheriting from `ActiveJob::Base`.

Two details worth calling out for review:

- **Ordering.** Resolving a constant is not inert: under Zeitwerk it triggers
  autoloading, which runs the body of whichever file defines it. Checking the
  allowlist first means a disallowed name never reaches the resolver. The
  earlier revision of this PR resolved first and checked the allowlist second,
  so a rejected message had already triggered the autoload. To be precise about
  severity: this is defense-in-depth, not a code-execution fix. `const_get`
  does not evaluate arbitrary Ruby, and the previous code called only
  `is_a?`, `<`, and `.name` on the resolved class before raising, so nothing was
  ever instantiated or invoked. Checking a string against a list is simply
  cheaper than resolving a constant, and doing the cheap check first is the
  right order regardless.
- **`inherit: false`.** Each segment must be defined directly on the preceding
  one, so a name like `SomeJob::Foo` cannot resolve `Foo` from `SomeJob`'s
  ancestors. Without this, `TestJob::ClassMethods` resolves to
  `ActiveJob::Exceptions::ClassMethods`.

## Errors and message handling

Invalid or disallowed job classes raise a dedicated `InvalidJobClassError`
rather than a broad `ArgumentError`, which keeps them distinct from errors
raised from inside a job's own `#perform` (those remain retryable).

`Executor#execute_task` treats `InvalidJobClassError` as a **permanent
failure**: the message content is immutable, so redelivering it can never
succeed, and on the default config it would crash-loop the poller. Such a
message is logged with its body (it cannot be inspected once deleted) and then
deleted. `JSON::ParserError` is handled the same way, for the same reason.

## Configuring the allowlist

Supported through all three existing configuration channels:

- **In code** - an array of `Class` objects or class-name `String`s.
- **YAML file** - a list of class names.
- **Environment** - `AWS_ACTIVE_JOB_SQS_JOB_CLASS_ALLOWLIST`, a comma-separated
  list of class names.

Entries are compared by class name, so the three channels behave identically.
Normalization happens at comparison time in `JobRunner`, which keeps
`Configuration` a plain accessor and handles all three input shapes uniformly.

Default remains `nil`, allowing any `ActiveJob::Base` subclass, so existing
behavior is preserved. Note that with no allowlist the reachable set is
unchanged from before this PR: `ActiveJob::Base.execute` resolves the class name
itself via `safe_constantize`, so the gate's value is that it raises during
`JobRunner#initialize`, before `run`. Deriving an implicit allowlist from
`ActiveJob::Base.descendants` was considered and rejected: this gem supports
non-Rails and Rails dev where jobs autoload lazily, so `descendants` is
near-empty in a fresh poller and legitimate jobs would be rejected.

## Tests

- Rejects classes that do not inherit from `ActiveJob::Base`.
- Rejects undefined classes.
- Rejects names that are not well-formed constant paths.
- Does not resolve the constant when the name is malformed, or when the
  allowlist excludes it (these pin the ordering).
- Does not resolve a name through an ancestor of the namespace.
- Allows / rejects classes against a `Class` allowlist, a string-array allowlist
  (YAML), and a comma-separated string allowlist (ENV, incl. whitespace
  trimming).
- Executor: logs and deletes a message whose job class is invalid.
- ENV loading of the new key is covered by the existing `GLOBAL_ENV_CONFIGS`
  loop in `configuration_spec.rb`.

Full suite: 100 examples, 0 failures. Rubocop clean.

The new ordering and `inherit: false` tests were checked against the previous
implementation and fail there, so they pin real behavior rather than passing
incidentally.

## Docs

- README: new "Restricting which job classes can run" section with code, YAML,
  and ENV examples, noting that the allowlist is checked before resolution and
  recommending it when the queue is reachable by anything you do not control.
- CHANGELOG: entries lead with customer impact.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.
