### PR TITLE
feat: Expose raw SQS message to ActiveJob instances via sqs_message acccessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Expose raw SQS message to ActiveJob instances via `sqs_message` accessor. Jobs can access the message to extend visibility timeout, read message attributes, or perform manual acknowledgement.
+
 1.0.2 (2025-04-01)
 ------------------
 

--- a/lib/aws-activejob-sqs.rb
+++ b/lib/aws-activejob-sqs.rb
@@ -10,6 +10,15 @@ require_relative 'aws/active_job/sqs/executor'
 require_relative 'aws/active_job/sqs/job_runner'
 require_relative 'aws/active_job/sqs/lambda_handler'
 
+# Expose the raw SQS message to jobs consumed from SQS queues.
+# This allows jobs to access message metadata, extend visibility timeout,
+# read message attributes, or perform manual acknowledgement.
+# The accessor is nil when the job is not executed via the SQS poller
+# (e.g. inline adapter, tests, or other queue backends).
+ActiveSupport.on_load(:active_job) do
+  attr_accessor :sqs_message
+end
+
 module Aws
   module ActiveJob
     # ActiveJob Adapter and backend queueing using AWS SQS.

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -8,13 +8,16 @@ module Aws
         attr_reader :id, :class_name
 
         def initialize(message)
+          @message = message
           @job_data = ActiveSupport::JSON.load(message.data.body)
           @class_name = @job_data['job_class'].constantize
           @id = @job_data['job_id']
         end
 
         def run
-          ::ActiveJob::Base.execute @job_data
+          job = ::ActiveJob::Base.deserialize(@job_data)
+          job.sqs_message = @message if job.respond_to?(:sqs_message=)
+          job.perform_now
         end
 
         def exception_executions?

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -14,10 +14,42 @@ module Aws
           expect(job_runner.instance_variable_get(:@job_data)).to eq job_data
         end
 
+        it 'stores the raw SQS message' do
+          job_runner = JobRunner.new(msg)
+          expect(job_runner.instance_variable_get(:@message)).to eq msg
+        end
+
         describe '#run' do
-          it 'calls Base.execute with the job data' do
-            expect(::ActiveJob::Base).to receive(:execute).with(job_data)
+          it 'deserializes the job and calls perform_now' do
+            job_instance = instance_double(TestJob)
+            allow(::ActiveJob::Base).to receive(:deserialize).with(job_data).and_return(job_instance)
+            allow(job_instance).to receive(:sqs_message=)
+            allow(job_instance).to receive(:perform_now)
+
             JobRunner.new(msg).run
+
+            expect(job_instance).to have_received(:perform_now)
+          end
+
+          it 'sets sqs_message on the job instance' do
+            job_instance = instance_double(TestJob)
+            allow(::ActiveJob::Base).to receive(:deserialize).with(job_data).and_return(job_instance)
+            allow(job_instance).to receive(:sqs_message=)
+            allow(job_instance).to receive(:perform_now)
+
+            JobRunner.new(msg).run
+
+            expect(job_instance).to have_received(:sqs_message=).with(msg)
+          end
+
+          it 'skips setting sqs_message if the job does not respond to it' do
+            job_instance = instance_double(TestJob)
+            allow(::ActiveJob::Base).to receive(:deserialize).with(job_data).and_return(job_instance)
+            allow(job_instance).to receive(:respond_to?).with(:sqs_message=).and_return(false)
+            allow(job_instance).to receive(:perform_now)
+
+            expect { JobRunner.new(msg).run }.not_to raise_error
+            expect(job_instance).to have_received(:perform_now)
           end
         end
       end

--- a/spec/aws/active_job/sqs/sqs_message_accessor_spec.rb
+++ b/spec/aws/active_job/sqs/sqs_message_accessor_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+describe 'ActiveJob::Base#sqs_message' do
+  it 'defines sqs_message accessor on ActiveJob::Base' do
+    job = TestJob.new('a1', 'a2')
+    expect(job).to respond_to(:sqs_message)
+    expect(job).to respond_to(:sqs_message=)
+  end
+
+  it 'defaults to nil' do
+    job = TestJob.new('a1', 'a2')
+    expect(job.sqs_message).to be_nil
+  end
+
+  it 'can be set and read' do
+    job = TestJob.new('a1', 'a2')
+    fake_message = double('sqs_message')
+    job.sqs_message = fake_message
+    expect(job.sqs_message).to eq(fake_message)
+  end
+end


### PR DESCRIPTION
*Description of changes:*

Add attr_accessor :sqs_message to ActiveJob::Base and inject the raw Aws::SQS::Message into job instances before execution. This allows jobs to access message metadata, extend visibility timeout, read message attributes, or perform manual acknowledgement.

Changes:
- Add sqs_message accessor to ActiveJob::Base via ActiveSupport.on_load
- Update JobRunner#run to use deserialize + perform_now (functionally equivalent to execute) so we can inject the message between deserialization and perform
- JobRunner stores the message and sets it on the job if it responds to sqs_message=

The accessor is nil when the job is not executed via the SQS poller (e.g. inline adapter, tests, or other queue backends).

Use cases:
- Extend visibility timeout for long-running jobs (heartbeat pattern)
- Read approximate_receive_count for custom retry logic
- Access message attributes/metadata for observability
- Manual delete for early acknowledgement

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
