### PR TITLE
fix: Validate FIFO delay before sending any batch messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - `perform_all_later` no longer partially enqueues a batch before raising when one of the jobs has a delay on a FIFO queue (#40).
+
 1.1.1 (2026-08-12)
 ------------------
 

--- a/lib/active_job/queue_adapters/sqs_adapter.rb
+++ b/lib/active_job/queue_adapters/sqs_adapter.rb
@@ -26,6 +26,12 @@ module ActiveJob
       end
 
       def enqueue_all(jobs)
+        jobs.each do |job|
+          next unless job.scheduled_at
+
+          validate_fifo_delay!(job, Params.assured_delay_seconds(job.scheduled_at))
+        end
+
         enqueued_count = 0
         jobs.group_by(&:queue_name).each do |queue_name, same_queue_jobs|
           enqueued_count += enqueue_batches(queue_name, same_queue_jobs)
@@ -58,11 +64,7 @@ module ActiveJob
       def batch_entry(job)
         entry = Params.new(job, nil).entry
         entry[:id] = job.job_id
-        if job.scheduled_at
-          delay = Params.assured_delay_seconds(job.scheduled_at)
-          validate_fifo_delay!(job, delay)
-          entry[:delay_seconds] = delay
-        end
+        entry[:delay_seconds] = Params.assured_delay_seconds(job.scheduled_at) if job.scheduled_at
         entry
       end
 

--- a/spec/active_job/queue_adapters/sqs_adapter_spec.rb
+++ b/spec/active_job/queue_adapters/sqs_adapter_spec.rb
@@ -120,6 +120,17 @@ module ActiveJob
             end.to raise_error(Aws::ActiveJob::SQS::FifoDelayNotSupportedError)
           end
 
+          it 'does not send any messages when a later job in the batch has a delay' do
+            expect(client).not_to receive(:send_message_batch)
+
+            jobs = Array.new(10) { TestJob.new('test') }
+            jobs << TestJob.new('test').set(wait: 1.minute)
+
+            expect do
+              ActiveJob.perform_all_later(jobs)
+            end.to raise_error(Aws::ActiveJob::SQS::FifoDelayNotSupportedError)
+          end
+
           it 'enqueues jobs with zero or negative delay' do
             expect(client).to receive(:send_message).with(
               hash_including(queue_url: 'https://queue-url.fifo', delay_seconds: 0)


### PR DESCRIPTION
*Issue #:* #40

*Description of changes:* On the batch path, a `perform_all_later` that mixed a delayed job with a FIFO queue could send part of the batch before raising. This moves that check up front so nothing is sent when it fails.

**Issue**
`perform_all_later` groups jobs and sends them in batches of ten. The FIFO per-message-delay check ran while building each batch, so on a call spanning more than one batch (over ten jobs) or mixing queues, `FifoDelayNotSupportedError` could be raised only after earlier batches were already sent. The caller then saw an exception with part of the batch already on the queue.

**Fix**
A FIFO delay is a client-side error we can detect without any network call, so validate every delayed job up front in `enqueue_all`, before any `send_message_batch`. The call is now all-or-nothing for this error. The old per-entry check in `batch_entry` was only reachable through `enqueue_all`, so it is now redundant and removed.

**Testing**
- Added a spec: a FIFO batch where a later job carries a delay sends no messages and raises.
- Existing FIFO and batch specs still pass; full suite green, rubocop clean.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.*

*Written with AI assistance and reviewed by jterapin.*