### PR TITLE
feat: Report dropped jobs and add optional permanent_failure_handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Feature - Report a dropped job to the Rails error reporter and add an optional `permanent_failure_handler` so apps can keep unresolvable jobs on the queue for redelivery instead of losing them (#39).
+
 * Issue - `perform_all_later` no longer partially enqueues a batch before raising when one of the jobs has a delay on a FIFO queue (#40).
 
 1.1.1 (2026-08-12)

--- a/README.md
+++ b/README.md
@@ -232,6 +232,40 @@ Aws::ActiveJob::SQS.configure do |config|
 end
 ```
 
+#### Permanently-failed messages
+
+Some messages can never run: an unparseable body, or a `job_class` that is
+malformed, not in your `job_class_allowlist`, or not defined in the process
+(raised as `Aws::ActiveJob::SQS::InvalidJobClassError`). The poller logs these
+and deletes them so they do not redeliver and crash-loop the worker. Because a
+single log line is easy to miss, the poller also reports the failure to the
+[Rails error reporter](https://guides.rubyonrails.org/error_reporting.html)
+(`Rails.error.report`), so it surfaces in whatever error tracker your app uses
+(Sentry, Datadog, CloudWatch, etc.). This is always on and needs no configuration.
+
+One case is recoverable: during a rolling deploy an older worker can receive a
+job for a class only newer workers have, raising
+`Aws::ActiveJob::SQS::JobClassNotDefinedError` (a subclass of
+`InvalidJobClassError`). To keep such a message on the queue so SQS can
+redeliver it to a newer worker, configure a `permanent_failure_handler` and
+`throw :skip_delete`:
+
+```ruby
+Aws::ActiveJob::SQS.configure do |config|
+  config.permanent_failure_handler = lambda do |error, _sqs_message|
+    # keep undefined-class messages on the queue for redelivery;
+    # everything else is deleted as usual
+    throw :skip_delete if error.is_a?(Aws::ActiveJob::SQS::JobClassNotDefinedError)
+  end
+end
+```
+
+The handler is called with `|error, sqs_message|` after the failure is
+reported and before the message is deleted. If it returns without throwing,
+the message is deleted as usual. Skipped messages stay on the queue and are
+redelivered per the queue's redrive/DLQ settings, so configure a DLQ to bound
+retries (otherwise a message that never resolves redelivers until the queue's
+retention period).
 
 When using the Async adapter, you may want to configure a
 `async_queue_error_handler` to handle errors that may occur when queuing jobs. 

--- a/README.md
+++ b/README.md
@@ -235,37 +235,30 @@ end
 #### Permanently-failed messages
 
 Some messages can never run: an unparseable body, or a `job_class` that is
-malformed, not in your `job_class_allowlist`, or not defined in the process
-(raised as `Aws::ActiveJob::SQS::InvalidJobClassError`). The poller logs these
-and deletes them so they do not redeliver and crash-loop the worker. Because a
-single log line is easy to miss, the poller also reports the failure to the
-[Rails error reporter](https://guides.rubyonrails.org/error_reporting.html)
-(`Rails.error.report`), so it surfaces in whatever error tracker your app uses
-(Sentry, Datadog, CloudWatch, etc.). This is always on and needs no configuration.
+malformed, disallowed by `job_class_allowlist`, or undefined in the process
+(all raised as `Aws::ActiveJob::SQS::InvalidJobClassError`). The poller logs
+and deletes these so they don't redeliver and crash-loop the worker (since
+1.1.0; previously an unparseable body redelivered to the DLQ), and
+reports them to the [Rails error reporter](https://guides.rubyonrails.org/error_reporting.html)
+(`Rails.error.report`) so the loss surfaces in your error tracker. Always on,
+no configuration needed.
 
 One case is recoverable: during a rolling deploy an older worker can receive a
-job for a class only newer workers have, raising
-`Aws::ActiveJob::SQS::JobClassNotDefinedError` (a subclass of
-`InvalidJobClassError`). To keep such a message on the queue so SQS can
-redeliver it to a newer worker, configure a `permanent_failure_handler` and
-`throw :skip_delete`:
+job for a class only newer workers define, raising `JobClassNotDefinedError`
+(a subclass of `InvalidJobClassError`). Configure a `permanent_failure_handler`
+and `throw :skip_delete` to keep such a message on the queue for redelivery:
 
 ```ruby
 Aws::ActiveJob::SQS.configure do |config|
   config.permanent_failure_handler = lambda do |error, _sqs_message|
-    # keep undefined-class messages on the queue for redelivery;
-    # everything else is deleted as usual
     throw :skip_delete if error.is_a?(Aws::ActiveJob::SQS::JobClassNotDefinedError)
   end
 end
 ```
 
-The handler is called with `|error, sqs_message|` after the failure is
-reported and before the message is deleted. If it returns without throwing,
-the message is deleted as usual. Skipped messages stay on the queue and are
-redelivered per the queue's redrive/DLQ settings, so configure a DLQ to bound
-retries (otherwise a message that never resolves redelivers until the queue's
-retention period).
+The handler runs after the failure is reported and before the message is
+deleted. Return without throwing and the message is deleted as usual; `throw
+:skip_delete` keeps it on the queue, so configure a DLQ to bound retries.
 
 When using the Async adapter, you may want to configure a
 `async_queue_error_handler` to handle errors that may occur when queuing jobs. 

--- a/lib/aws/active_job/sqs/configuration.rb
+++ b/lib/aws/active_job/sqs/configuration.rb
@@ -48,7 +48,7 @@ module Aws
       # {GLOBAL_ENV_CONFIGS}.  For supported queue specific ENV configurations
       # see: {QUEUE_ENV_CONFIGS}.
       #
-      class Configuration
+      class Configuration # rubocop:disable Metrics/ClassLength
         # Default configuration options
         # @api private
         DEFAULTS = {

--- a/lib/aws/active_job/sqs/configuration.rb
+++ b/lib/aws/active_job/sqs/configuration.rb
@@ -125,6 +125,37 @@ module Aws
         #   receive settings). Retries provided by this mechanism are
         #   after any retries configured on the job with `retry_on`.
         #
+        # @option options [Callable] :permanent_failure_handler a handler for
+        #   messages the poller is about to drop as permanently failed (an
+        #   unparseable body, or an invalid job class: see
+        #   {InvalidJobClassError}).
+        #
+        #   Called as `(error, sqs_message)` just before the message would be
+        #   deleted.
+        #
+        #   - Return normally: the message is deleted and reported to the
+        #     app's error tracker as a dropped job.
+        #   - `throw :skip_delete`: the message stays on the queue for
+        #     redelivery (subject to redrive/DLQ settings) and is not reported
+        #     as dropped. This lets a newer worker recover a
+        #     {JobClassNotDefinedError} raised mid rolling-deploy.
+        #
+        #   Only a {JobClassNotDefinedError} is recoverable this way. An
+        #   unparseable body, and the other {InvalidJobClassError} causes, will
+        #   fail identically on every redelivery, so throw only for the
+        #   recoverable case or you will pin an unprocessable message on the
+        #   queue:
+        #
+        #       config.permanent_failure_handler = lambda do |error, _message|
+        #         if error.is_a?(Aws::ActiveJob::SQS::JobClassNotDefinedError)
+        #           throw :skip_delete
+        #         end
+        #       end
+        #
+        #   Applies to the poller only. The Lambda handler does not invoke this
+        #   handler; there, a permanent failure fails the invocation and the
+        #   message redelivers until it hits the queue's redrive/DLQ limit.
+        #
         # @option options [ActiveSupport::Logger] :logger Logger to use
         #   for the poller.
         #
@@ -177,7 +208,7 @@ module Aws
 
         # @api private
         attr_writer :max_messages, :message_group_id, :visibility_timeout,
-                    :poller_error_handler, :client
+                    :poller_error_handler, :permanent_failure_handler, :client
 
         def excluded_deduplication_keys=(keys)
           @excluded_deduplication_keys = keys.map(&:to_s) | ['job_id']
@@ -186,6 +217,11 @@ module Aws
         def poller_error_handler(&block)
           @poller_error_handler = block if block_given?
           @poller_error_handler
+        end
+
+        def permanent_failure_handler(&block)
+          @permanent_failure_handler = block if block_given?
+          @permanent_failure_handler
         end
 
         def client

--- a/lib/aws/active_job/sqs/configuration.rb
+++ b/lib/aws/active_job/sqs/configuration.rb
@@ -125,36 +125,15 @@ module Aws
         #   receive settings). Retries provided by this mechanism are
         #   after any retries configured on the job with `retry_on`.
         #
-        # @option options [Callable] :permanent_failure_handler a handler for
-        #   messages the poller is about to drop as permanently failed (an
-        #   unparseable body, or an invalid job class: see
-        #   {InvalidJobClassError}).
-        #
-        #   Called as `(error, sqs_message)` just before the message would be
-        #   deleted.
-        #
-        #   - Return normally: the message is deleted and reported to the
-        #     app's error tracker as a dropped job.
-        #   - `throw :skip_delete`: the message stays on the queue for
-        #     redelivery (subject to redrive/DLQ settings) and is not reported
-        #     as dropped. This lets a newer worker recover a
-        #     {JobClassNotDefinedError} raised mid rolling-deploy.
-        #
-        #   Only a {JobClassNotDefinedError} is recoverable this way. An
-        #   unparseable body, and the other {InvalidJobClassError} causes, will
-        #   fail identically on every redelivery, so throw only for the
-        #   recoverable case or you will pin an unprocessable message on the
-        #   queue:
-        #
-        #       config.permanent_failure_handler = lambda do |error, _message|
-        #         if error.is_a?(Aws::ActiveJob::SQS::JobClassNotDefinedError)
-        #           throw :skip_delete
-        #         end
-        #       end
-        #
-        #   Applies to the poller only. The Lambda handler does not invoke this
-        #   handler; there, a permanent failure fails the invocation and the
-        #   message redelivers until it hits the queue's redrive/DLQ limit.
+        # @option options [Callable] :permanent_failure_handler a handler called
+        #   as `(error, sqs_message)` just before the poller deletes a
+        #   permanently-failed message (unparseable body or an
+        #   {InvalidJobClassError}). Return normally to delete and report the
+        #   drop; `throw :skip_delete` to keep the message on the queue for
+        #   redelivery and skip the report. Intended for recovering a
+        #   {JobClassNotDefinedError} raised mid rolling-deploy; throwing for
+        #   other causes will pin an unprocessable message on the queue. Poller
+        #   only; the Lambda handler ignores it. See the README for details.
         #
         # @option options [ActiveSupport::Logger] :logger Logger to use
         #   for the poller.

--- a/lib/aws/active_job/sqs/executor.rb
+++ b/lib/aws/active_job/sqs/executor.rb
@@ -94,25 +94,62 @@ module Aws
           # An unparseable body is a permanent failure: the message content is
           # immutable, so re-parsing it on redelivery can never succeed. Log and
           # delete it so it does not redeliver indefinitely.
-          drop_permanent_failure(message, "Unable to parse message body: #{message.data.body}. Error: #{e}.")
+          parser_msg = "Unable to parse message body: #{message.data.body}. Error: #{e}."
+          drop_permanent_failure(message, e, parser_msg)
         rescue InvalidJobClassError => e
           # A bad job class is a permanent failure: redelivering it can never
           # succeed and, on the default config, would crash-loop the poller.
           # Log the forensic detail (the message can't be inspected in a DLQ
           # once deleted) and delete it so it does not redeliver.
-          drop_permanent_failure(message, "Rejecting message #{message.message_id}: #{e}. " \
-                                          "Body: #{message.data.body}. Deleting so it does not redeliver.")
+          invalid_msg =
+            "Rejecting message #{message.message_id}: #{e}. " \
+            "Body: #{message.data.body}. Deleting so it does not redeliver."
+          drop_permanent_failure(message, e, invalid_msg)
         rescue StandardError => e
           handle_standard_error(e, job, message)
         ensure
           @task_complete.set
         end
 
-        # Log a permanently-failed message and delete it so SQS does not
-        # redeliver it (which, on the default config, would crash-loop the poller).
-        def drop_permanent_failure(message, log_message)
+        # Handle a permanently-failed message (unparseable body or invalid job
+        # class). Always logged. A dropped message is also reported to the
+        # error tracker so the loss is visible beyond the logs, then deleted so
+        # SQS won't redeliver. A configured +permanent_failure_handler+ can
+        # +throw :skip_delete+ to keep the message on the queue for redelivery
+        # instead, in which case it is neither reported nor deleted.
+        def drop_permanent_failure(message, error, log_message)
           @logger.error log_message
-          message.delete
+
+          handler = Aws::ActiveJob::SQS.config.permanent_failure_handler
+          unless handler
+            report_permanent_failure(error, message)
+            return message.delete
+          end
+
+          catch(:skip_delete) do
+            begin
+              handler.call(error, message)
+            rescue StandardError => e
+              @logger.error "permanent_failure_handler raised: #{e}"
+            end
+            report_permanent_failure(error, message)
+            message.delete
+          end
+        end
+
+        # Report a permanently-dropped job to the application's error tracker
+        # via Rails' error reporter (Rails 7+), if available, so the loss
+        # surfaces in whatever tracker the app uses. A no-op outside Rails.
+        # Only called when the message is actually deleted, so a message kept
+        # for redelivery via +:skip_delete+ is not reported as dropped.
+        def report_permanent_failure(error, message)
+          return unless defined?(::Rails) && ::Rails.respond_to?(:error)
+
+          ::Rails.error.report(
+            error,
+            handled: true,
+            context: { message_id: message.message_id, body: message.data.body }
+          )
         end
 
         def handle_standard_error(error, job, message)

--- a/lib/aws/active_job/sqs/executor.rb
+++ b/lib/aws/active_job/sqs/executor.rb
@@ -85,7 +85,7 @@ module Aws
           end
         end
 
-        def execute_task(message)
+        def execute_task(message) # rubocop:disable Metrics/MethodLength
           job = JobRunner.new(message)
           @logger.info("Running job: #{job.id}[#{job.class_name}]")
           job.run

--- a/lib/aws/active_job/sqs/job_runner.rb
+++ b/lib/aws/active_job/sqs/job_runner.rb
@@ -11,6 +11,16 @@ module Aws
       # deletes it rather than letting it redeliver.
       class InvalidJobClassError < StandardError; end
 
+      # Raised when a message names a class not defined in this process.
+      #
+      # Recoverable in a way other {InvalidJobClassError} causes (malformed
+      # name, disallowed class, non-job class) aren't: during a rolling deploy,
+      # redelivering to a newer worker that has the class may succeed. Subclasses
+      # {InvalidJobClassError} so existing rescues still catch it; a
+      # +permanent_failure_handler+ can single it out and keep the message on
+      # the queue for redelivery.
+      class JobClassNotDefinedError < InvalidJobClassError; end
+
       # @api private
       class JobRunner
         # A job class name is an (optionally namespaced) constant path and
@@ -65,12 +75,14 @@ module Aws
         # segment must be defined directly on the preceding one: a name such
         # as 'SomeJob::Foo' cannot resolve Foo from SomeJob's ancestors when
         # SomeJob itself does not define it. NameError is treated as a
-        # rejection rather than propagated: an unknown class is the same
-        # permanent failure as a disallowed one.
+        # rejection rather than propagated, but as the recoverable
+        # {JobClassNotDefinedError} subclass: an undefined class may just be
+        # missing from this process (e.g. mid rolling-deploy), unlike a
+        # malformed or disallowed name.
         def constantize_job_class(name)
           Object.const_get(name, false)
         rescue NameError
-          raise InvalidJobClassError, "#{name} is not defined"
+          raise JobClassNotDefinedError, "Job Class: #{name} is not defined"
         end
 
         # The allowlist may be configured as an Array of Class values (in code),

--- a/spec/aws/active_job/sqs/configuration_spec.rb
+++ b/spec/aws/active_job/sqs/configuration_spec.rb
@@ -150,6 +150,16 @@ module Aws
           end
         end
 
+        describe '#permanent_failure_handler' do
+          it 'allows configuration through a block' do
+            cfg = Aws::ActiveJob::SQS::Configuration.new
+            cfg.permanent_failure_handler do
+              #  pass
+            end
+            expect(cfg.permanent_failure_handler).to be_a(Proc)
+          end
+        end
+
         Configuration::QUEUE_CONFIGS.each do |config_name|
           describe "##{config_name}_for" do
             let(:cfg) do

--- a/spec/aws/active_job/sqs/executor_spec.rb
+++ b/spec/aws/active_job/sqs/executor_spec.rb
@@ -44,7 +44,7 @@ module Aws
           it 'deletes the message and does not re-raise when the job class is invalid' do
             expect(JobRunner).to receive(:new).and_raise(InvalidJobClassError, 'File is not a valid job class')
             expect(msg).to receive(:delete)
-            expect(msg).to receive(:message_id).and_return('stub-id')
+            allow(msg).to receive(:message_id).and_return('stub-id')
             expect do
               executor.execute(msg)
               sleep(0.1) if defined?(JRUBY_VERSION)
@@ -55,11 +55,79 @@ module Aws
           it 'deletes the message and does not re-raise when the body cannot be parsed' do
             expect(JobRunner).to receive(:new).and_raise(JSON::ParserError.new('unexpected token'))
             expect(msg).to receive(:delete)
+            allow(msg).to receive(:message_id).and_return('stub-id')
             expect do
               executor.execute(msg)
               sleep(0.1) if defined?(JRUBY_VERSION)
               executor.shutdown # give the task a chance to run
             end.not_to raise_error
+          end
+
+          describe 'permanent failures' do
+            let(:error) { InvalidJobClassError.new('File is not a valid job class') }
+
+            before do
+              expect(JobRunner).to receive(:new).and_raise(error)
+              allow(msg).to receive(:message_id).and_return('stub-id')
+            end
+
+            it 'reports the failure to the error tracker before deleting' do
+              allow(msg).to receive(:delete)
+              expect(Rails.error).to receive(:report).with(
+                error,
+                handled: true,
+                context: { message_id: 'stub-id', body: body }
+              )
+              executor.execute(msg)
+              sleep(0.1) if defined?(JRUBY_VERSION)
+              executor.shutdown
+            end
+
+            context 'a permanent_failure_handler is configured' do
+              after { Aws::ActiveJob::SQS.config.permanent_failure_handler = nil }
+
+              it 'calls the handler with the error and message, then deletes' do
+                handler = double
+                expect(handler).to receive(:call).with(error, msg)
+                Aws::ActiveJob::SQS.config.permanent_failure_handler = handler
+                expect(msg).to receive(:delete)
+                executor.execute(msg)
+                sleep(0.1) if defined?(JRUBY_VERSION)
+                executor.shutdown
+              end
+
+              it 'leaves the message on the queue when the handler throws :skip_delete' do
+                Aws::ActiveJob::SQS.config.permanent_failure_handler =
+                  ->(_error, _message) { throw :skip_delete }
+                expect(msg).not_to receive(:delete)
+                expect do
+                  executor.execute(msg)
+                  sleep(0.1) if defined?(JRUBY_VERSION)
+                  executor.shutdown
+                end.not_to raise_error
+              end
+
+              it 'does not report to the error tracker when the handler throws :skip_delete' do
+                Aws::ActiveJob::SQS.config.permanent_failure_handler =
+                  ->(_error, _message) { throw :skip_delete }
+                expect(Rails.error).not_to receive(:report)
+                expect(msg).not_to receive(:delete)
+                executor.execute(msg)
+                sleep(0.1) if defined?(JRUBY_VERSION)
+                executor.shutdown
+              end
+
+              it 'deletes the message when the handler itself raises' do
+                Aws::ActiveJob::SQS.config.permanent_failure_handler =
+                  ->(_error, _message) { raise 'handler boom' }
+                expect(msg).to receive(:delete)
+                expect do
+                  executor.execute(msg)
+                  sleep(0.1) if defined?(JRUBY_VERSION)
+                  executor.shutdown
+                end.not_to raise_error
+              end
+            end
           end
 
           describe 'error_handler' do

--- a/spec/aws/active_job/sqs/job_runner_spec.rb
+++ b/spec/aws/active_job/sqs/job_runner_spec.rb
@@ -31,9 +31,15 @@ module Aws
               .to raise_error(InvalidJobClassError, /must inherit from ActiveJob::Base/)
           end
 
-          it 'rejects undefined classes' do
+          it 'rejects undefined classes with the recoverable JobClassNotDefinedError' do
             expect { JobRunner.new(msg_for('NoSuchJob')) }
-              .to raise_error(InvalidJobClassError, /is not defined/)
+              .to raise_error(JobClassNotDefinedError, /is not defined/)
+          end
+
+          it 'raises JobClassNotDefinedError as an InvalidJobClassError so existing rescues still catch it' do
+            expect(JobClassNotDefinedError).to be < InvalidJobClassError
+            expect { JobRunner.new(msg_for('NoSuchJob')) }
+              .to raise_error(InvalidJobClassError)
           end
 
           it 'rejects names that are not well-formed constant paths' do


### PR DESCRIPTION
*Issue #, if available:* #39

*Description of changes:*

When the poller hits a permanent failure (an unparseable body, or a job class it can't load), it deletes the message. That makes the loss invisible and gives no way to recover a job that fails only because an old worker is mid rolling-deploy. This adds visibility and an opt-in recovery path, with no change to the default behavior.

- Dropped jobs are reported to the Rails error reporter (Rails 7+), so the loss surfaces in the app's error tracker.
- New optional `permanent_failure_handler`, called just before a permanent failure is deleted. `throw :skip_delete` keeps the message on the queue for redelivery.
- New `JobClassNotDefinedError` (a subclass of `InvalidJobClassError`) marks the recoverable case, so a handler can keep only the messages a newer worker might run.
- The error report fires only when a message is actually dropped, not when a handler keeps it.
- A handler that raises is logged and the message is deleted anyway, so a buggy handler can't pin messages on the queue.
- Invalid job classes are still deleted by default; recovery happens only when an app opts in with a handler.
- Poller only; the Lambda handler is unchanged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---
Written with AI assistance and reviewed by jterapin.